### PR TITLE
Utility mixin check/cleanup

### DIFF
--- a/src/scss/_badge.scss
+++ b/src/scss/_badge.scss
@@ -1,12 +1,12 @@
 .badge {
-  border-radius: $badge-border-radius; // allow badge border radius to be customized outside of the global border-radius rules
+  @include border-radius($badge-border-radius); // allow badge border radius to be customized outside of the global border-radius rules
   letter-spacing: $letter-spacing-base;
   text-transform: uppercase;
   vertical-align: baseline;
 
   // Use chained selector to successfully override custom border-radius on .badge class
   &.badge-pill {
-    border-radius: $badge-pill-border-radius;
+    @include border-radius($badge-pill-border-radius);
   }
 }
 

--- a/src/scss/_jumbotron.scss
+++ b/src/scss/_jumbotron.scss
@@ -1,4 +1,4 @@
 .jumbotron {
   // Allow for configurable border-radius
-  border-radius: $jumbotron-border-radius;
+  @include border-radius($jumbotron-border-radius);
 }

--- a/src/scss/_modal.scss
+++ b/src/scss/_modal.scss
@@ -2,7 +2,7 @@
 // Actual modal
 //
 .modal-content {
-  border-radius: $modal-border-radius;
+  @include border-radius($modal-border-radius); // Allow for configurable border-radius
   // Reset text color within the modal, in case a parent element adjusts the text color
   color: $body-color;
 }

--- a/src/scss/_tooltip.scss
+++ b/src/scss/_tooltip.scss
@@ -8,5 +8,5 @@
 }
 
 .tooltip-inner {
-  border-radius: $tooltip-border-radius;
+  @include border-radius($tooltip-border-radius); // Allow for configurable border-radius
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -784,7 +784,6 @@ $zindex-tooltip:            1070;
 
 // Navbar
 
-$navbar-border-radius:              $border-radius;
 $navbar-padding-x:                  $spacer;
 $navbar-padding-y:                  0; // modified
 


### PR DESCRIPTION
Reviewed where mixins related to Bootstrap options (e.g. $enabled-rounded, $enable-shadows) should be used in Athena so that those options can take effect when changed.  We've only been modifying per-component border-radius values up to this point, so I updated where those are overridden manually to use the border-radius() mixin.