### PR TITLE
Version script updates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -341,7 +341,9 @@ gulp.task('gh-build-pages', function() {
 
   process.env.JEKYLL_ENV = 'production';
 
-  const jekyll = childProc.spawnSync('jekyll', [
+  const jekyll = childProc.spawnSync('bundle', [
+    'exec',
+    'jekyll',
     'build',
     '--config=_config.yml,_config_prod.yml'
   ]);

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "tether": "^1.4.0"
   },
   "scripts": {
-    "version": "gulp config-gh-pages && cd docs/ && jekyll build && git add --all"
+    "version": "gulp default && gulp gh-pages && git add --all"
   }
 }


### PR DESCRIPTION
- Updated npm version script to run `gulp default` and `gulp gh-pages` (ensures documentation css/js are rebuilt with latest changes)
- Removed manual `jekyll build` step in the npm version script, since `gulp gh-pages` already performs it
- Updated command in `gh-build-pages` to run `bundle exec`, allowing `jekyll build` to run in the context of our _docs/ folder.  More info: http://bundler.io/man/bundle-exec.1.html

Resolves #76.