### PR TITLE
framework.min.css charset rule on first line

### DIFF
--- a/_docs/static/css/docs.min.css
+++ b/_docs/static/css/docs.min.css
@@ -1,9 +1,10 @@
+@charset "UTF-8";
 /*!
  * Athena Framework v1.0.3 (https://ucf.github.io/Athena-Framework)
  * Copyright 2017-2019 UCF Web Communications
  * Licensed under MIT
  */
-@charset "UTF-8";/*!
+/*!
  * Bootstrap v4.0.0-alpha.6 (https://getbootstrap.com)
  * Copyright 2011-2017 The Bootstrap Authors
  * Copyright 2011-2017 Twitter, Inc.

--- a/dist/css/framework.min.css
+++ b/dist/css/framework.min.css
@@ -1,9 +1,10 @@
+@charset "UTF-8";
 /*!
  * Athena Framework v1.0.3 (https://ucf.github.io/Athena-Framework)
  * Copyright 2017-2019 UCF Web Communications
  * Licensed under MIT
  */
-@charset "UTF-8";/*!
+/*!
  * Bootstrap v4.0.0-alpha.6 (https://getbootstrap.com)
  * Copyright 2011-2017 The Bootstrap Authors
  * Copyright 2011-2017 Twitter, Inc.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,6 +110,10 @@ function buildCSS(src, filename, dest, applyHeader) {
     .pipe(gulpif(applyHeader, header(config.prj.header, {
       config: config
     })))
+    // Remove charset rule (if present) and add to the first
+    // line of the stylesheet (@charset must be on the first line)
+    .pipe(replace('@charset "UTF-8";', ''))
+    .pipe(header('@charset "UTF-8";\n'))
     .pipe(rename(filename))
     .pipe(gulp.dest(dest));
 }


### PR DESCRIPTION
<!---
Thank you for contributing to the Athena Framework.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Athena-Framework/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Replaces + re-adds `@charset` rule in minified framework css to ensure it's always on the first line of the document.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #150

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested locally for any charset/encoding errors from the minified document in the console (Firefox) and saw none.  Can also verify the update in dist/css/framework.min.css

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
