### PR TITLE
Replaced slash as division in Sass files

### DIFF
--- a/_docs/_src/scss/_component-examples.scss
+++ b/_docs/_src/scss/_component-examples.scss
@@ -329,7 +329,7 @@
 
 .highlight {
   background-color: $gray-lightest;
-  margin: 1rem (-$grid-gutter-width-base / 2);
+  margin: 1rem (-$grid-gutter-width-base * .5);
   -ms-overflow-style: -ms-autohiding-scrollbar;
   padding: 1rem;
 

--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -45,7 +45,7 @@ select.form-control {
 
 .form-check-input {
   height: 1em; // for browsers that can display them a little bit larger
-  margin-right: $form-check-input-margin-x / 2; // Fix text-indent effect on label's first line
+  margin-right: $form-check-input-margin-x * .5; // Fix text-indent effect on label's first line
   width: 1em; // for browsers that can display them a little bit larger
 }
 
@@ -150,9 +150,9 @@ select.form-control-lg {
 // Search input field icon
 .form-control-search {
   background-image: $form-icon-search;
-  background-position: center right ($input-height / 4);
+  background-position: center right ($input-height * .25);
   background-repeat: no-repeat;
-  background-size: ($input-height / 2) ($input-height / 2);
+  background-size: ($input-height * .5) ($input-height * .5);
   padding-right: ($input-padding-x * 3);
 }
 

--- a/src/scss/_navbar.scss
+++ b/src/scss/_navbar.scss
@@ -291,7 +291,7 @@
           @include media-breakpoint-down($breakpoint) {
             // Fixed left padding needs to be added here to match up with
             // grid gutters
-            padding-left: ($grid-gutter-width-base / 2);
+            padding-left: ($grid-gutter-width-base * .5);
           }
 
           @include media-breakpoint-down(nth(map-keys($grid-breakpoints), 1)) {
@@ -304,7 +304,7 @@
           @include media-breakpoint-down($breakpoint) {
             // Fixed left padding needs to be added here to match up with
             // grid gutters
-            margin-right: ($grid-gutter-width-base / 2);
+            margin-right: ($grid-gutter-width-base * .5);
           }
 
           @include media-breakpoint-down(nth(map-keys($grid-breakpoints), 1)) {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -42,6 +42,8 @@
 // Close
 // Code
 
+@use 'sass:math';
+
 @mixin _assert-ascending($map, $map-name) {
   $prev-key: null;
   $prev-num: null;
@@ -94,7 +96,7 @@
 //
 @function strip-unit($number) {
   @if type-of($number) == 'number' and not unitless($number) {
-    @return $number / ($number * 0 + 1);
+    @return math.div($number, $number * 0 + 1);
   }
 
   @return $number;
@@ -517,7 +519,7 @@ $font-serif-heading-size-ratio:      1.1 !default; // custom
 $font-slab-serif-heading-size-ratio: 1.15 !default; // custom
 $font-condensed-heading-size-ratio:  1.75 !default; // custom
 
-$headings-margin-bottom:   ($spacer / 2) !default;
+$headings-margin-bottom:   ($spacer * .5) !default;
 $headings-font-family:     inherit !default;
 $headings-font-weight:     600 !default; // modified
 $headings-line-height:     map-get($line-height, 1) !default; // modified, but same calculated value as Bootstrap
@@ -707,10 +709,10 @@ $btn-padding-y-lg:               1.25rem !default; // modified
 // but are as consistent with Bootstrap's naming conventions as possible.
 $btn-font-size:                  $font-size-base !default;
 $btn-font-size-md:               $font-size-base-md !default;
-$btn-sm-font-size:               ($font-size-base * $font-size-sm) / 1rem !default;
-$btn-sm-font-size-md:            ($font-size-base-md * $font-size-sm) / 1rem !default;
-$btn-lg-font-size:               ($font-size-base * $font-size-lg) / 1rem !default;
-$btn-lg-font-size-md:            ($font-size-base-md * $font-size-lg) / 1rem !default;
+$btn-sm-font-size:               math.div($font-size-base * $font-size-sm, 1rem) !default;
+$btn-sm-font-size-md:            math.div($font-size-base-md * $font-size-sm, 1rem) !default;
+$btn-lg-font-size:               math.div($font-size-base * $font-size-lg, 1rem) !default;
+$btn-lg-font-size-md:            math.div($font-size-base-md * $font-size-lg, 1rem) !default;
 
 $btn-block-spacing-y:            .5rem !default;
 $btn-toolbar-margin:             .5rem !default;
@@ -728,7 +730,7 @@ $btn-transition:                 all .2s ease-in-out !default;
 // Forms
 
 $input-padding-x:                .75rem !default;
-$input-padding-y:                $btn-padding-y - (($font-size-base-md - $btn-font-size) / 2) !default; // modified
+$input-padding-y:                $btn-padding-y - (($font-size-base-md - $btn-font-size) * .5) !default; // modified
 $input-padding-y-md:             $btn-padding-y !default; // custom
 $input-line-height:              $btn-line-height !default; // modified
 
@@ -752,11 +754,11 @@ $input-color-focus:              $input-color !default;
 $input-color-placeholder:        $gray-dark !default; // modified
 
 $input-padding-x-sm:             .5rem !default;
-$input-padding-y-sm:             $btn-padding-y-sm - (($font-size-sm - $btn-sm-font-size) / 2) !default; // modified
+$input-padding-y-sm:             $btn-padding-y-sm - (($font-size-sm - $btn-sm-font-size) * .5) !default; // modified
 $input-padding-y-sm-md:          $btn-padding-y-sm !default; // custom; if anyone has any better variable name ideas, please feel free to edit...
 
 $input-padding-x-lg:             1.5rem !default;
-$input-padding-y-lg:             $btn-padding-y-lg - (($font-size-lg - $btn-lg-font-size) / 2) !default; // modified
+$input-padding-y-lg:             $btn-padding-y-lg - (($font-size-lg - $btn-lg-font-size) * .5) !default; // modified
 $input-padding-y-lg-md:          $btn-padding-y-lg !default; // custom; if anyone has any better variable name ideas, please feel free to edit...
 
 $input-height:                   (($font-size-base-md * $input-line-height) + ($input-padding-y * 2)) !default; // modified
@@ -794,7 +796,7 @@ $custom-control-spacer-x: 1rem !default;
 $custom-control-spacer-y: .25rem !default;
 
 $custom-control-indicator-size:         1rem !default;
-$custom-control-indicator-margin-y:     (($line-height-base * 1rem) - $custom-control-indicator-size) / -2 !default;
+$custom-control-indicator-margin-y:     math.div(($line-height-base * 1rem) - $custom-control-indicator-size, -2) !default;
 $custom-control-indicator-bg:           $white !default; // modified
 $custom-control-indicator-bg-size:      50% 50% !default;
 $custom-control-indicator-box-shadow:   inset 0 .25rem .25rem rgba($black, .1) !default;
@@ -986,7 +988,7 @@ $navbar-nav-link-font-size:           $font-size-xs !default; // custom
 $navbar-nav-link-line-height:         1.2 !default; // custom
 $navbar-nav-link-padding-x:           .8rem !default; // custom
 $navbar-nav-link-padding-y:           1.5rem !default; // custom
-$navbar-collapsed-nav-link-padding-x: ($grid-gutter-width-base / 2) !default; // custom
+$navbar-collapsed-nav-link-padding-x: ($grid-gutter-width-base * .5) !default; // custom
 $navbar-collapsed-nav-link-padding-y: 1rem !default; // custom
 
 $navbar-form-inline-padding-y:      $navbar-toggler-margin-y !default; // custom
@@ -997,8 +999,8 @@ $navbar-form-inline-padding-y:      $navbar-toggler-margin-y !default; // custom
 $nav-item-margin:               .2rem !default;
 $nav-item-inline-spacer:        1rem !default;
 $nav-link-padding:              .5em 1em !default; // unused in Athena
-$nav-link-padding-x:            $grid-gutter-width-base / 2 !default; // custom; should not exceed the current grid gutter width (see _nav.scss)
-$nav-link-padding-y:            $grid-gutter-width-base / 4 !default; // custom
+$nav-link-padding-x:            $grid-gutter-width-base * .5 !default; // custom; should not exceed the current grid gutter width (see _nav.scss)
+$nav-link-padding-y:            $grid-gutter-width-base * .25 !default; // custom
 $nav-link-hover-bg:             rgba($black, .1) !default; // modified
 $nav-disabled-link-color:       $gray-dark !default; // modified
 
@@ -1092,7 +1094,7 @@ $card-link-hover-color:    $white !default;
 
 $card-img-overlay-padding: 1.25rem !default;
 
-$card-deck-margin:          ($grid-gutter-width-base / 2) !default;
+$card-deck-margin:          ($grid-gutter-width-base * .5) !default;
 
 $card-columns-count:        3 !default;
 $card-columns-gap:          1.25rem !default;
@@ -1356,5 +1358,5 @@ $filter-blur:       blur(5px) !default; // custom
 // Variables below are no longer utilized in Athena and will be removed
 // in a future major release.  They should not be used in new projects.
 
-$line-height-lg: (4 / 3) !default;
+$line-height-lg: math.div(4, 3) !default;
 $line-height-sm: map-get($line-height, 5) !default; // modified, but same calculated value as Bootstrap

--- a/src/scss/bootstrap/_card.scss
+++ b/src/scss/bootstrap/_card.scss
@@ -23,7 +23,7 @@
 }
 
 .card-subtitle {
-  margin-top: -($card-spacer-y / 2);
+  margin-top: -($card-spacer-y * .5);
   margin-bottom: 0;
 }
 
@@ -87,15 +87,15 @@
 //
 
 .card-header-tabs {
-  margin-right: -($card-spacer-x / 2);
+  margin-right: -($card-spacer-x * .5);
   margin-bottom: -$card-spacer-y;
-  margin-left: -($card-spacer-x / 2);
+  margin-left: -($card-spacer-x * .5);
   border-bottom: 0;
 }
 
 .card-header-pills {
-  margin-right: -($card-spacer-x / 2);
-  margin-left: -($card-spacer-x / 2);
+  margin-right: -($card-spacer-x * .5);
+  margin-left: -($card-spacer-x * .5);
 }
 
 

--- a/src/scss/bootstrap/_custom-forms.scss
+++ b/src/scss/bootstrap/_custom-forms.scss
@@ -59,7 +59,7 @@
 
 .custom-control-indicator {
   position: absolute;
-  top: (($line-height-base - $custom-control-indicator-size) / 2);
+  top: (($line-height-base - $custom-control-indicator-size) * .5);
   left: 0;
   display: block;
   width: $custom-control-indicator-size;

--- a/src/scss/bootstrap/_forms.scss
+++ b/src/scss/bootstrap/_forms.scss
@@ -256,8 +256,8 @@ select.form-control-lg {
 .form-control-danger {
   padding-right: ($input-padding-x * 3);
   background-repeat: no-repeat;
-  background-position: center right ($input-height / 4);
-  background-size: ($input-height / 2) ($input-height / 2);
+  background-position: center right ($input-height * .25);
+  background-size: ($input-height * .5) ($input-height * .5);
 }
 
 // Form validation states

--- a/src/scss/bootstrap/_images.scss
+++ b/src/scss/bootstrap/_images.scss
@@ -33,7 +33,7 @@
 }
 
 .figure-img {
-  margin-bottom: ($spacer-y / 2);
+  margin-bottom: ($spacer-y * .5);
   line-height: 1;
 }
 

--- a/src/scss/bootstrap/_jumbotron.scss
+++ b/src/scss/bootstrap/_jumbotron.scss
@@ -1,5 +1,5 @@
 .jumbotron {
-  padding: $jumbotron-padding ($jumbotron-padding / 2);
+  padding: $jumbotron-padding ($jumbotron-padding * .5);
   margin-bottom: $jumbotron-padding;
   background-color: $jumbotron-bg;
   @include border-radius($border-radius-lg);

--- a/src/scss/bootstrap/_responsive-embed.scss
+++ b/src/scss/bootstrap/_responsive-embed.scss
@@ -1,5 +1,7 @@
 // Credit: Nicolas Gallagher and SUIT CSS.
 
+@use 'sass:math';
+
 .embed-responsive {
   position: relative;
   display: block;
@@ -29,24 +31,24 @@
 
 .embed-responsive-21by9 {
   &::before {
-    padding-top: percentage(9 / 21);
+    padding-top: percentage(math.div(9, 21));
   }
 }
 
 .embed-responsive-16by9 {
   &::before {
-    padding-top: percentage(9 / 16);
+    padding-top: percentage(math.div(9, 16));
   }
 }
 
 .embed-responsive-4by3 {
   &::before {
-    padding-top: percentage(3 / 4);
+    padding-top: percentage(3 * .25);
   }
 }
 
 .embed-responsive-1by1 {
   &::before {
-    padding-top: percentage(1 / 1);
+    padding-top: percentage(math.div(1, 1));
   }
 }

--- a/src/scss/bootstrap/_type.scss
+++ b/src/scss/bootstrap/_type.scss
@@ -108,7 +108,7 @@ mark,
 
 // Blockquotes
 .blockquote {
-  padding: ($spacer / 2) $spacer;
+  padding: ($spacer * .5) $spacer;
   margin-bottom: $spacer;
   font-size: $blockquote-font-size;
   border-left: $blockquote-border-width solid $blockquote-border-color;

--- a/src/scss/bootstrap/mixins/_grid.scss
+++ b/src/scss/bootstrap/mixins/_grid.scss
@@ -2,6 +2,8 @@
 //
 // Generate semantic grid columns with these mixins.
 
+@use 'sass:math';
+
 @mixin make-container($gutters: $grid-gutter-widths) {
   position: relative;
   margin-left: auto;
@@ -10,8 +12,8 @@
   @each $breakpoint in map-keys($gutters) {
     @include media-breakpoint-up($breakpoint) {
       $gutter: map-get($gutters, $breakpoint);
-      padding-right: ($gutter / 2);
-      padding-left:  ($gutter / 2);
+      padding-right: ($gutter * .5);
+      padding-left:  ($gutter * .5);
     }
   }
 }
@@ -31,8 +33,8 @@
   @each $breakpoint in map-keys($gutters) {
     @include media-breakpoint-up($breakpoint) {
       $gutter: map-get($gutters, $breakpoint);
-      padding-right: ($gutter / 2);
-      padding-left:  ($gutter / 2);
+      padding-right: ($gutter * .5);
+      padding-left:  ($gutter * .5);
     }
   }
 }
@@ -44,8 +46,8 @@
   @each $breakpoint in map-keys($gutters) {
     @include media-breakpoint-up($breakpoint) {
       $gutter: map-get($gutters, $breakpoint);
-      margin-right: ($gutter / -2);
-      margin-left:  ($gutter / -2);
+      margin-right: math.div($gutter, -2);
+      margin-left:  math.div($gutter, -2);
     }
   }
 }
@@ -61,31 +63,31 @@
   @each $breakpoint in map-keys($gutters) {
     @include media-breakpoint-up($breakpoint) {
       $gutter: map-get($gutters, $breakpoint);
-      padding-right: ($gutter / 2);
-      padding-left:  ($gutter / 2);
+      padding-right: ($gutter * .5);
+      padding-left:  ($gutter * .5);
     }
   }
 }
 
 @mixin make-col($size, $columns: $grid-columns) {
-  flex: 0 0 percentage($size / $columns);
+  flex: 0 0 percentage(math.div($size, $columns));
   // width: percentage($size / $columns);
   // Add a `max-width` to ensure content within each column does not blow out
   // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
   // do not appear to require this.
-  max-width: percentage($size / $columns);
+  max-width: percentage(math.div($size, $columns));
 }
 
 @mixin make-col-offset($size, $columns: $grid-columns) {
-  margin-left: percentage($size / $columns);
+  margin-left: percentage(math.div($size, $columns));
 }
 
 @mixin make-col-push($size, $columns: $grid-columns) {
-  left: if($size > 0, percentage($size / $columns), auto);
+  left: if($size > 0, percentage(math.div($size, $columns)), auto);
 }
 
 @mixin make-col-pull($size, $columns: $grid-columns) {
-  right: if($size > 0, percentage($size / $columns), auto);
+  right: if($size > 0, percentage(math.div($size, $columns)), auto);
 }
 
 @mixin make-col-modifier($type, $size, $columns) {

--- a/src/scss/bootstrap/mixins/_nav-divider.scss
+++ b/src/scss/bootstrap/mixins/_nav-divider.scss
@@ -4,7 +4,7 @@
 
 @mixin nav-divider($color: #e5e5e5) {
   height: 1px;
-  margin: ($spacer-y / 2) 0;
+  margin: ($spacer-y * .5) 0;
   overflow: hidden;
   background-color: $color;
 }


### PR DESCRIPTION
<!---
Thank you for contributing to the Athena Framework.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Athena-Framework/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Ran [Sass's provided migrator](https://sass-lang.com/documentation/breaking-changes/slash-div#automatic-migration) for transitioning away from using `/` as a division operator, tidied up resulting linter issues, and re-ran `gulp setup`.  No minified css changes were tracked, so the changes made by the migrator result in the same end code.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To suppress the waterfall of deprecation warnings about using "/" for division when building Athena and any project that includes Athena assets.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Gulp tasks tested locally.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
